### PR TITLE
Fix configs and functions for distributed rank checks

### DIFF
--- a/configs/base/dfine_hgnetv2.yml
+++ b/configs/base/dfine_hgnetv2.yml
@@ -22,7 +22,7 @@ no_aug_epoch: 0
 
 HGNetv2:
   pretrained: True
-  local_model_dir: ../RT-DETR-main/D-FINE/weight/hgnetv2/
+  local_model_dir: ./weight/hgnetv2/
 
 HybridEncoder:
   in_channels: [512, 1024, 2048]

--- a/configs/deim_dfine/deim_hgnetv2_n_coco.yml
+++ b/configs/deim_dfine/deim_hgnetv2_n_coco.yml
@@ -3,7 +3,7 @@ __include__: [
   '../base/deim.yml'
 ]
 
-output_dir: ./deim_outputs/deim_hgnetv2_n_coco
+output_dir: ./outputs/deim_hgnetv2_n_coco
 
 optimizer:
   type: AdamW

--- a/configs/deim_dfine/dfine_hgnetv2_n_coco.yml
+++ b/configs/deim_dfine/dfine_hgnetv2_n_coco.yml
@@ -68,7 +68,6 @@ optimizer:
 # Increase to search for the optimal ema
 epoches: 160 # 148 + 4n
 train_dataloader:
-  total_batch_size: 128
   dataset:
     transforms:
       policy:
@@ -77,6 +76,3 @@ train_dataloader:
     stop_epoch: 148
     ema_restart_decay: 0.9999
     base_size_repeat: ~
-
-val_dataloader:
-  total_batch_size: 256

--- a/engine/backbone/hgnetv2.py
+++ b/engine/backbone/hgnetv2.py
@@ -12,6 +12,7 @@ import os
 from .common import FrozenBatchNorm2d
 from ..core import register
 import logging
+from ..misc.dist_utils import get_rank, is_dist_available_and_initialized
 
 # Constants for initialization
 kaiming_normal_ = nn.init.kaiming_normal_
@@ -495,11 +496,12 @@ class HGNetv2(nn.Module):
                     print(f"Loaded stage1 {name} HGNetV2 from local file.")
                 else:
                     # If the file doesn't exist locally, download from the URL
-                    if torch.distributed.get_rank() == 0:
+                    if get_rank() == 0:
                         print(GREEN + "If the pretrained HGNetV2 can't be downloaded automatically. Please check your network connection." + RESET)
                         print(GREEN + "Please check your network connection. Or download the model manually from " + RESET + f"{download_url}" + GREEN + " to " + RESET + f"{local_model_dir}." + RESET)
                         state = torch.hub.load_state_dict_from_url(download_url, map_location='cpu', model_dir=local_model_dir)
-                        torch.distributed.barrier()
+                        if is_dist_available_and_initialized():
+                            torch.distributed.barrier()
                     else:
                         torch.distributed.barrier()
                         state = torch.load(local_model_dir)
@@ -509,7 +511,7 @@ class HGNetv2(nn.Module):
                 self.load_state_dict(state)
 
             except (Exception, KeyboardInterrupt) as e:
-                if torch.distributed.get_rank() == 0:
+                if get_rank() == 0:
                     print(f"{str(e)}")
                     logging.error(RED + "CRITICAL WARNING: Failed to load pretrained HGNetV2 model" + RESET)
                     logging.error(GREEN + "Please check your network connection. Or download the model manually from " \


### PR DESCRIPTION
Include the following four modifications.

configs/base/dfine_hgnetv2.yml: The weight file is currently being downloaded to an unusual location. Modified so that it downloads directly into the project folder for convenience.

configs/deim_dfine/deim_hgnetv2_n_coco.yml: The output_dir in this file is inconsistent with other models. Updated to maintain consistency.

configs/deim_dfine/dfine_hgnetv2_n_coco.yml: This file is the only one that directly specifies total_batch_size in train_dataloader and val_dataloader. Because of this, as noted in the README, modifying total_batch_size in configs/base/dataloader.yml does not properly affect training when using deim_hgnetv2_n. Fixed for consistency with the intended configuration behavior.

engine/backbone/hgnetv2.py: When training with a single GPU, the rank-checking function for loading HGNetV2 pretraining weights causes an error. This has been corrected.